### PR TITLE
Fix issues preventing danbooru scraping

### DIFF
--- a/input_manager.py
+++ b/input_manager.py
@@ -171,6 +171,18 @@ def options():
     else:
         merged_post_count_type = DEFAULTS["merged_post_count_type"]
 
+    # If scraping danbooru, the user-agent must contain _a_ user id
+    if choice_site == 1 or choice_site == 3:
+        dbr_user_id = get_input(
+            "What's your danbooru user id? (can be found here when logged in: https://danbooru.donmai.us/profile)",
+            -1,
+            int
+        )
+        # For details: https://danbooru.donmai.us/wiki_pages/help:api
+        dbr_headers = {"User-Agent": f"danbooru-e621-tag-list-processor/1.0 (user {dbr_user_id})"}
+    else:
+        dbr_headers = None
+
     min_post_thresh = get_input(
         "Enter min. number of posts for a tag to be kept (tags with fewer posts will be ignored)",
         DEFAULTS["min_post_thresh"],
@@ -270,4 +282,5 @@ def options():
         "create_krita_csv": create_krita_csv,
         # "create_wildcard": create_wildcard,
         # "wildcard_categories": wildcard_categories,
+        "dbr_headers": dbr_headers
     }

--- a/tag_lists/danbooru.py
+++ b/tag_lists/danbooru.py
@@ -18,7 +18,7 @@ def stop_if_below_post_threshold(item, settings):
 
 
 async def process_dbr_tags_async(settings):
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=settings.get("dbr_headers")) as session:
         df1_target = DBR_SCRAPE_TARGETS.get(1)  # 1 = Tags, 2 = Aliases
         df1_json = await scrape_target(
             session,
@@ -103,6 +103,7 @@ async def scrape_target(session, url, target_name, stop_check=None, settings=Non
         # Launch a batch of tasks (each task is one page)
         tasks = [scrape_page(session, url, page + i) for i in range(batch_size)]
         raw_results = await asyncio.gather(*tasks)
+        await asyncio.sleep(2)  # in order to avoid getting rate limited
         results = []
         pages_with_status = []
 


### PR DESCRIPTION
- Add custom User-Agent header for danbooru requests
- Add timeout between danbooru batched to prevent being rate-limited

Without a proper user agent (see [wiki](https://danbooru.donmai.us/wiki_pages/help:api)) the script is not authorized to hit the different endpoints (403).